### PR TITLE
Target to and adjust for .NET 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # PrimeFuncPack
-A Functional Programming Pack for .NET Standard
+A Functional Programming Pack for .NET

--- a/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Box/Box.Equality.cs
+++ b/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Box/Box.Equality.cs
@@ -1,10 +1,12 @@
 ﻿#nullable enable
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace System
 {
     partial class Box
     {
-        public static bool Equals<T>(in Box<T>? boxA, in Box<T>? boxB)
+        public static bool Equals<T>([AllowNull] in Box<T> boxA, [AllowNull] in Box<T> boxB)
             =>
             Box<T>.Equals(boxA, boxB);
     }

--- a/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Box/Box.Sameness.cs
+++ b/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Box/Box.Sameness.cs
@@ -1,10 +1,12 @@
 ﻿#nullable enable
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace System
 {
     partial class Box
     {
-        public static bool Same<T>(in Box<T>? boxA, in Box<T>? boxB)
+        public static bool Same<T>([AllowNull] in Box<T> boxA, [AllowNull] in Box<T> boxB)
             =>
             Box<T>.Same(boxA, boxB);
     }

--- a/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Box/Box.T.Equality.cs
+++ b/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Box/Box.T.Equality.cs
@@ -1,27 +1,28 @@
 ﻿#nullable enable
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace System
 {
     partial class Box<T>
     {
-        public static bool Equals(in Box<T>? boxA, in Box<T>? boxB)
+        public static bool Equals([AllowNull] in Box<T> boxA, [AllowNull] in Box<T> boxB)
             =>
             ReferenceEquals(boxA, boxB) ||
             boxA is object &&
             boxB is object &&
             EqualityComparer<T>.Default.Equals(boxA, boxB);
 
-        public static bool operator ==(in Box<T>? boxA, in Box<T>? boxB)
+        public static bool operator ==([AllowNull] in Box<T> boxA, [AllowNull] in Box<T> boxB)
             =>
             Equals(boxA, boxB);
 
-        public static bool operator !=(in Box<T>? boxA, in Box<T>? boxB)
+        public static bool operator !=([AllowNull] in Box<T> boxA, [AllowNull] in Box<T> boxB)
             =>
             Equals(boxA, boxB) is false;
 
-        public bool Equals(Box<T>? other)
+        public bool Equals([AllowNull] Box<T> other)
             =>
             Equals(this, other);
 

--- a/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Box/Box.T.Sameness.cs
+++ b/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Box/Box.T.Sameness.cs
@@ -1,14 +1,16 @@
 ﻿#nullable enable
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace System
 {
     partial class Box<T>
     {
-        public static bool Same(in Box<T>? boxA, in Box<T>? boxB)
+        public static bool Same([AllowNull] in Box<T> boxA, [AllowNull] in Box<T> boxB)
             =>
             ReferenceEquals(boxA, boxB);
 
-        public bool Same(in Box<T>? other)
+        public bool Same([AllowNull] in Box<T> other)
             =>
             Same(this, other);
 

--- a/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Box/Box.T.cs
+++ b/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Box/Box.T.cs
@@ -3,8 +3,8 @@
 namespace System
 {
     public sealed partial class Box<T> :
-        IEquatable<Box<T>?>,
-        ISamenessEquatable<Box<T>?>
+        IEquatable<Box<T>>,
+        ISamenessEquatable<Box<T>>
     {
         public T Value { get; }
 
@@ -12,8 +12,8 @@ namespace System
             =>
             box.Value;
 
-        public override string? ToString()
+        public override string ToString()
             =>
-            Value switch { null => string.Empty, var present => present.ToString() };
+            Value?.ToString() ?? string.Empty;
     }
 }

--- a/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Box/BoxEqualityComparer.cs
+++ b/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Box/BoxEqualityComparer.cs
@@ -1,16 +1,17 @@
 ﻿#nullable enable
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace System
 {
-    public sealed class BoxEqualityComparer<T> : IEqualityComparer<Box<T>?>
+    public sealed class BoxEqualityComparer<T> : IEqualityComparer<Box<T>>
     {
-        public bool Equals(Box<T>? x, Box<T>? y)
+        public bool Equals([AllowNull] Box<T> x, [AllowNull] Box<T> y)
             =>
             Box<T>.Equals(x, y);
 
-        public int GetHashCode(Box<T>? obj) => obj switch
+        public int GetHashCode([DisallowNull] Box<T> obj) => obj switch
         {
             null => throw new ArgumentNullException(nameof(obj)),
             var present => present.GetHashCode()

--- a/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Box/BoxSamenessComparer.cs
+++ b/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Box/BoxSamenessComparer.cs
@@ -1,16 +1,17 @@
 ﻿#nullable enable
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace System
 {
-    public sealed class BoxSamenessComparer<T> : IEqualityComparer<Box<T>?>
+    public sealed class BoxSamenessComparer<T> : IEqualityComparer<Box<T>>
     {
-        public bool Equals(Box<T>? x, Box<T>? y)
+        public bool Equals([AllowNull] Box<T> x, [AllowNull] Box<T> y)
             =>
             Box<T>.Same(x, y);
 
-        public int GetHashCode(Box<T>? obj) => obj switch
+        public int GetHashCode([DisallowNull] Box<T> obj) => obj switch
         {
             null => throw new ArgumentNullException(nameof(obj)),
             var present => present.GetSamenessHashCode()

--- a/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Box/PrimeFuncPack.Core.Box.csproj
+++ b/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Box/PrimeFuncPack.Core.Box.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>netstandard2.1</TargetFramework>
+		<TargetFramework>net5.0</TargetFramework>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 		<Authors>Andrei Sergeev, Pavel Moskovoy</Authors>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/PrimeFuncPack.Core/PrimeFuncPack.Core.ISamenessEquatable/ISamenessEquatable.cs
+++ b/src/PrimeFuncPack.Core/PrimeFuncPack.Core.ISamenessEquatable/ISamenessEquatable.cs
@@ -1,10 +1,12 @@
 ﻿#nullable enable
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace System
 {
     public interface ISamenessEquatable<T>
     {
-        bool Same(in T other);
+        bool Same([AllowNull] in T other);
 
         int GetSamenessHashCode();
     }

--- a/src/PrimeFuncPack.Core/PrimeFuncPack.Core.ISamenessEquatable/PrimeFuncPack.Core.ISamenessEquatable.csproj
+++ b/src/PrimeFuncPack.Core/PrimeFuncPack.Core.ISamenessEquatable/PrimeFuncPack.Core.ISamenessEquatable.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>netstandard2.1</TargetFramework>
+		<TargetFramework>net5.0</TargetFramework>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 		<Authors>Andrei Sergeev, Pavel Moskovoy</Authors>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Linq/PrimeFuncPack.Core.Linq.csproj
+++ b/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Linq/PrimeFuncPack.Core.Linq.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>netstandard2.1</TargetFramework>
+		<TargetFramework>net5.0</TargetFramework>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 		<Authors>Andrei Sergeev, Pavel Moskovoy</Authors>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Linq.Dictionaries/GetValueOrAbsent.IReadOnlyDictionary.cs
+++ b/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Linq.Dictionaries/GetValueOrAbsent.IReadOnlyDictionary.cs
@@ -1,6 +1,7 @@
 ﻿#nullable enable
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace System.Linq
 {
@@ -19,10 +20,11 @@ namespace System.Linq
         }
 
         [Obsolete(ObsoleteMessages.TryGetValueOrAbsent, error: true)]
+        [DoesNotReturn]
         public static Optional<TValue> TryGetValueOrAbsent<TKey, TValue>(
             this IReadOnlyDictionary<TKey, TValue> dictionary,
             in TKey key)
             =>
-            dictionary.GetValueOrAbsent(key);
+            throw new NotImplementedException(ObsoleteMessages.TryGetValueOrAbsent);
     }
 }

--- a/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Linq.Dictionaries/GetValueOrAbsent.cs
+++ b/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Linq.Dictionaries/GetValueOrAbsent.cs
@@ -1,6 +1,7 @@
 ﻿#nullable enable
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace System.Linq
 {
@@ -32,10 +33,11 @@ namespace System.Linq
         }
 
         [Obsolete(ObsoleteMessages.TryGetValueOrAbsent, error: true)]
+        [DoesNotReturn]
         public static Optional<TValue> TryGetValueOrAbsent<TKey, TValue>(
             this IEnumerable<KeyValuePair<TKey, TValue>> dictionary,
             in TKey key)
             =>
-            dictionary.GetValueOrAbsent(key);
+            throw new NotImplementedException(ObsoleteMessages.TryGetValueOrAbsent);
     }
 }

--- a/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Linq.Dictionaries/Internal/InternalGetValueOrAbsent.IDictionary.cs
+++ b/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Linq.Dictionaries/Internal/InternalGetValueOrAbsent.IDictionary.cs
@@ -9,11 +9,13 @@ namespace System.Linq
         public static Optional<TValue> InternalGetValueOrAbsent<TKey, TValue>(
             this IDictionary<TKey, TValue> dictionary,
             in TKey key)
-            =>
-            dictionary.TryGetValue(key, out var value) switch
+        {
+            if (dictionary.TryGetValue(key, out var value))
             {
-                true => Optional.Present(value),
-                _ => default
-            };
+                return Optional.Present(value);
+            }
+
+            return default;
+        }
     }
 }

--- a/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Linq.Dictionaries/Internal/InternalGetValueOrAbsent.IReadOnlyDictionary.cs
+++ b/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Linq.Dictionaries/Internal/InternalGetValueOrAbsent.IReadOnlyDictionary.cs
@@ -9,11 +9,13 @@ namespace System.Linq
         public static Optional<TValue> InternalGetValueOrAbsent<TKey, TValue>(
             this IReadOnlyDictionary<TKey, TValue> dictionary,
             in TKey key)
-            =>
-            dictionary.TryGetValue(key, out var value) switch
+        {
+            if (dictionary.TryGetValue(key, out var value))
             {
-                true => Optional.Present(value),
-                _ => default
-            };
+                return Optional.Present(value);
+            }
+
+            return default;
+        }
     }
 }

--- a/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Optional.Factory.cs
+++ b/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Optional.Factory.cs
@@ -1,5 +1,7 @@
 ﻿#nullable enable
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace System
 {
     partial class Optional
@@ -12,7 +14,7 @@ namespace System
             =>
             Optional<T>.Present(value);
 
-        public static Optional<T> PresentOrThrow<T>(in T value)
+        public static Optional<T> PresentOrThrow<T>([DisallowNull] in T value)
             =>
             Optional<T>.PresentOrThrow(value);
 

--- a/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Optional.T.Factory.cs
+++ b/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Optional.T.Factory.cs
@@ -1,5 +1,7 @@
 ﻿#nullable enable
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace System
 {
     partial struct Optional<T>
@@ -14,7 +16,7 @@ namespace System
             =>
             new Optional<T>(value);
 
-        public static Optional<T> PresentOrThrow(in T value) => value switch
+        public static Optional<T> PresentOrThrow([DisallowNull] in T value) => value switch
         {
             null
             =>

--- a/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Optional.T.OrThrowStrict.cs
+++ b/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Optional.T.OrThrowStrict.cs
@@ -1,0 +1,20 @@
+﻿#nullable enable
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace System
+{
+    partial struct Optional<T>
+    {
+        [return: NotNull]
+        public T OrThrowStrict()
+        {
+            if (box is null || box.Value is null)
+            {
+                throw new InvalidOperationException("The optional does not have a not null value.");
+            }
+
+            return box.Value;
+        }
+    }
+}

--- a/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Optional.T.cs
+++ b/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Optional.T.cs
@@ -12,8 +12,8 @@ namespace System
 
         public bool IsAbsent => box is null;
 
-        public override string? ToString()
+        public override string ToString()
             =>
-            box switch { null => string.Empty, var present => present.ToString() };
+            box?.ToString() ?? string.Empty;
     }
 }

--- a/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/PrimeFuncPack.Core.Optional.csproj
+++ b/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/PrimeFuncPack.Core.Optional.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>netstandard2.1</TargetFramework>
+		<TargetFramework>net5.0</TargetFramework>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 		<Authors>Andrei Sergeev, Pavel Moskovoy</Authors>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Unit/PrimeFuncPack.Core.Unit.csproj
+++ b/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Unit/PrimeFuncPack.Core.Unit.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>netstandard2.1</TargetFramework>
+		<TargetFramework>net5.0</TargetFramework>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 		<Authors>Andrei Sergeev, Pavel Moskovoy</Authors>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/PrimeFuncPack.Core/PrimeFuncPack.Core/PrimeFuncPack.Core.csproj
+++ b/src/PrimeFuncPack.Core/PrimeFuncPack.Core/PrimeFuncPack.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>netstandard2.1</TargetFramework>
+		<TargetFramework>net5.0</TargetFramework>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 		<Authors>Andrei Sergeev, Pavel Moskovoy</Authors>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/PrimeFuncPack.DependencyInjection/PrimeFuncPack.DependencyInjection/PrimeFuncPack.DependencyInjection.csproj
+++ b/src/PrimeFuncPack.DependencyInjection/PrimeFuncPack.DependencyInjection/PrimeFuncPack.DependencyInjection.csproj
@@ -1,26 +1,26 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <Authors>Andrei Sergeev, Pavel Moskovoy</Authors>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
-    <Description>PrimeFuncPack: A Functional Programming Pack for .NET Standard</Description>
-    <Copyright>Copyright © 2020 Andrei Sergeev, Pavel Moskovoy</Copyright>
-    <Version>1.0.0-preview.1.0.0</Version>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>net5.0</TargetFramework>
+		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+		<Authors>Andrei Sergeev, Pavel Moskovoy</Authors>
+		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+		<PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+		<PackageLicenseFile>LICENSE</PackageLicenseFile>
+		<Description>PrimeFuncPack: A Functional Programming Pack for .NET Standard</Description>
+		<Copyright>Copyright © 2020 Andrei Sergeev, Pavel Moskovoy</Copyright>
+		<Version>1.0.0-preview.1.0.0</Version>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <None Include="..\..\..\LICENSE">
-      <Pack>True</Pack>
-      <PackagePath></PackagePath>
-    </None>
-  </ItemGroup>
+	<ItemGroup>
+		<None Include="..\..\..\LICENSE">
+			<Pack>True</Pack>
+			<PackagePath></PackagePath>
+		</None>
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.*" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0-preview.*" />
+	</ItemGroup>
 
 </Project>

--- a/src/PrimeFuncPack/PrimeFuncPack/PrimeFuncPack.csproj
+++ b/src/PrimeFuncPack/PrimeFuncPack/PrimeFuncPack.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>netstandard2.1</TargetFramework>
+		<TargetFramework>net5.0</TargetFramework>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 		<Authors>Andrei Sergeev, Pavel Moskovoy</Authors>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>


### PR DESCRIPTION
It looks like .NET Stardard 2.1 and .NET Core 3.1 are going to be merged into only .NET 5.0 that is going to get the united .NET platform.

I've found some issues in .NET 5.0 that look like breaking changes to both .NET Stardard 2.1 and .NET Core 3.1.

So, it looks like we should target PrimeFuncPack for .NET 5.0 (and above) to write modern sources right away and prevent huge update of the sources in the future.