### PR TITLE
Migrate to C# 9; Apply more functional approach

### DIFF
--- a/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Box/Box.T.Equality.cs
+++ b/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Box/Box.T.Equality.cs
@@ -12,8 +12,8 @@ namespace System
         public static bool Equals([AllowNull] in Box<T> boxA, [AllowNull] in Box<T> boxB)
             =>
             ReferenceEquals(boxA, boxB) ||
-            boxA is object &&
-            boxB is object &&
+            boxA is not null &&
+            boxB is not null &&
             ValueEqualityComparer.Equals(boxA, boxB);
 
         public static bool operator ==([AllowNull] in Box<T> boxA, [AllowNull] in Box<T> boxB)

--- a/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Linq.Collections/ForEach.IReadOnlyList.cs
+++ b/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Linq.Collections/ForEach.IReadOnlyList.cs
@@ -10,15 +10,8 @@ namespace System.Linq
             this IReadOnlyList<TSource> source,
             in Action<TSource> action)
         {
-            if (source is null)
-            {
-                throw new ArgumentNullException(nameof(source));
-            }
-
-            if (action is null)
-            {
-                throw new ArgumentNullException(nameof(action));
-            }
+            _ = source ?? throw new ArgumentNullException(nameof(source));
+            _ = action ?? throw new ArgumentNullException(nameof(action));
 
             source.InternalForEach(action);
 
@@ -29,15 +22,8 @@ namespace System.Linq
             this IReadOnlyList<TSource> source,
             in Action<int, TSource> action)
         {
-            if (source is null)
-            {
-                throw new ArgumentNullException(nameof(source));
-            }
-
-            if (action is null)
-            {
-                throw new ArgumentNullException(nameof(action));
-            }
+            _ = source ?? throw new ArgumentNullException(nameof(source));
+            _ = action ?? throw new ArgumentNullException(nameof(action));
 
             source.InternalForEach(action);
 
@@ -48,15 +34,8 @@ namespace System.Linq
             this IReadOnlyList<TSource> source,
             in Action<long, TSource> action)
         {
-            if (source is null)
-            {
-                throw new ArgumentNullException(nameof(source));
-            }
-
-            if (action is null)
-            {
-                throw new ArgumentNullException(nameof(action));
-            }
+            _ = source ?? throw new ArgumentNullException(nameof(source));
+            _ = action ?? throw new ArgumentNullException(nameof(action));
 
             source.InternalForEach(action);
 

--- a/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Linq.Collections/ForEach.cs
+++ b/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Linq.Collections/ForEach.cs
@@ -11,15 +11,8 @@ namespace System.Linq
             in Action<TSource> action)
             where TCollection : IEnumerable<TSource>
         {
-            if (source is null)
-            {
-                throw new ArgumentNullException(nameof(source));
-            }
-
-            if (action is null)
-            {
-                throw new ArgumentNullException(nameof(action));
-            }
+            _ = source ?? throw new ArgumentNullException(nameof(source));
+            _ = action ?? throw new ArgumentNullException(nameof(action));
 
             switch (source)
             {
@@ -44,15 +37,8 @@ namespace System.Linq
             in Action<int, TSource> action)
             where TCollection : IEnumerable<TSource>
         {
-            if (source is null)
-            {
-                throw new ArgumentNullException(nameof(source));
-            }
-
-            if (action is null)
-            {
-                throw new ArgumentNullException(nameof(action));
-            }
+            _ = source ?? throw new ArgumentNullException(nameof(source));
+            _ = action ?? throw new ArgumentNullException(nameof(action));
 
             switch (source)
             {
@@ -77,15 +63,8 @@ namespace System.Linq
             in Action<long, TSource> action)
             where TCollection : IEnumerable<TSource>
         {
-            if (source is null)
-            {
-                throw new ArgumentNullException(nameof(source));
-            }
-
-            if (action is null)
-            {
-                throw new ArgumentNullException(nameof(action));
-            }
+            _ = source ?? throw new ArgumentNullException(nameof(source));
+            _ = action ?? throw new ArgumentNullException(nameof(action));
 
             switch (source)
             {

--- a/src/PrimeFuncPack.Core/PrimeFuncPack.Core.NullPredicates/NullPredicates.cs
+++ b/src/PrimeFuncPack.Core/PrimeFuncPack.Core.NullPredicates/NullPredicates.cs
@@ -4,7 +4,7 @@ namespace System
 {
     public static class NullPredicates
     {
-        public static bool IsNotNull<T>(in T value) => value is object;
+        public static bool IsNotNull<T>(in T value) => value is not null;
 
         public static bool IsNotNull<T>(T value) => IsNotNull(in value);
 

--- a/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Linq.Dictionaries/GetValueOrAbsent.IReadOnlyDictionary.cs
+++ b/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Linq.Dictionaries/GetValueOrAbsent.IReadOnlyDictionary.cs
@@ -11,10 +11,7 @@ namespace System.Linq
             this IReadOnlyDictionary<TKey, TValue> dictionary,
             in TKey key)
         {
-            if (dictionary is null)
-            {
-                throw new ArgumentNullException(nameof(dictionary));
-            }
+            _ = dictionary ?? throw new ArgumentNullException(nameof(dictionary));
 
             return dictionary.InternalGetValueOrAbsent(key);
         }

--- a/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Linq.Dictionaries/GetValueOrAbsent.cs
+++ b/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Linq.Dictionaries/GetValueOrAbsent.cs
@@ -11,10 +11,7 @@ namespace System.Linq
             this IEnumerable<KeyValuePair<TKey, TValue>> dictionary,
             in TKey key)
         {
-            if (dictionary is null)
-            {
-                throw new ArgumentNullException(nameof(dictionary));
-            }
+            _ = dictionary ?? throw new ArgumentNullException(nameof(dictionary));
 
             return dictionary switch
             {

--- a/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Linq/ElementAtOrAbsent.IReadOnlyList.cs
+++ b/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Linq/ElementAtOrAbsent.IReadOnlyList.cs
@@ -10,10 +10,7 @@ namespace System.Linq
             this IReadOnlyList<TSource> source,
             in int index)
         {
-            if (source is null)
-            {
-                throw new ArgumentNullException(nameof(source));
-            }
+            _ = source ?? throw new ArgumentNullException(nameof(source));
 
             return source.InternalElementAtOrAbsent(index);
         }
@@ -22,10 +19,7 @@ namespace System.Linq
             this IReadOnlyList<TSource> source,
             in long index)
         {
-            if (source is null)
-            {
-                throw new ArgumentNullException(nameof(source));
-            }
+            _ = source ?? throw new ArgumentNullException(nameof(source));
 
             return source.InternalElementAtOrAbsent(index);
         }

--- a/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Linq/ElementAtOrAbsent.cs
+++ b/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Linq/ElementAtOrAbsent.cs
@@ -10,10 +10,7 @@ namespace System.Linq
             this IEnumerable<TSource> source,
             in int index)
         {
-            if (source is null)
-            {
-                throw new ArgumentNullException(nameof(source));
-            }
+            _ = source ?? throw new ArgumentNullException(nameof(source));
 
             return source switch
             {
@@ -35,10 +32,7 @@ namespace System.Linq
             this IEnumerable<TSource> source,
             in long index)
         {
-            if (source is null)
-            {
-                throw new ArgumentNullException(nameof(source));
-            }
+            _ = source ?? throw new ArgumentNullException(nameof(source));
 
             return source switch
             {

--- a/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Linq/FirstOrAbsent.IReadOnlyList.cs
+++ b/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Linq/FirstOrAbsent.IReadOnlyList.cs
@@ -9,10 +9,7 @@ namespace System.Linq
         public static Optional<TSource> FirstOrAbsent<TSource>(
             this IReadOnlyList<TSource> source)
         {
-            if (source is null)
-            {
-                throw new ArgumentNullException(nameof(source));
-            }
+            _ = source ?? throw new ArgumentNullException(nameof(source));
 
             return source.InternalFirstOrAbsent();
         }
@@ -21,15 +18,8 @@ namespace System.Linq
             this IReadOnlyList<TSource> source,
             in Func<TSource, bool> predicate)
         {
-            if (source is null)
-            {
-                throw new ArgumentNullException(nameof(source));
-            }
-
-            if (predicate is null)
-            {
-                throw new ArgumentNullException(nameof(predicate));
-            }
+            _ = source ?? throw new ArgumentNullException(nameof(source));
+            _ = predicate ?? throw new ArgumentNullException(nameof(predicate));
 
             return source.InternalFirstOrAbsent(predicate);
         }

--- a/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Linq/FirstOrAbsent.cs
+++ b/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Linq/FirstOrAbsent.cs
@@ -9,10 +9,7 @@ namespace System.Linq
         public static Optional<TSource> FirstOrAbsent<TSource>(
             this IEnumerable<TSource> source)
         {
-            if (source is null)
-            {
-                throw new ArgumentNullException(nameof(source));
-            }
+            _ = source ?? throw new ArgumentNullException(nameof(source));
 
             return source switch
             {
@@ -34,15 +31,8 @@ namespace System.Linq
             this IEnumerable<TSource> source,
             in Func<TSource, bool> predicate)
         {
-            if (source is null)
-            {
-                throw new ArgumentNullException(nameof(source));
-            }
-
-            if (predicate is null)
-            {
-                throw new ArgumentNullException(nameof(predicate));
-            }
+            _ = source ?? throw new ArgumentNullException(nameof(source));
+            _ = predicate ?? throw new ArgumentNullException(nameof(predicate));
 
             return source switch
             {

--- a/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Linq/Internal/InternalElementAtOrAbsent.IList.cs
+++ b/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Linq/Internal/InternalElementAtOrAbsent.IList.cs
@@ -10,7 +10,7 @@ namespace System.Linq
             this IList<TSource> source,
             in int index)
             =>
-            (index >= 0 && index < source.Count) switch
+            InternalIsInRange(index, source.Count) switch
             {
                 true => Optional.Present(source[index]),
                 _ => default
@@ -20,9 +20,9 @@ namespace System.Linq
             this IList<TSource> source,
             in long index)
             =>
-            unchecked((int)index) switch
+            InternalShortenIndex(index) switch
             {
-                var indexShortened when indexShortened == index
+                int indexShortened when indexShortened == index
                 =>
                 source.InternalElementAtOrAbsent(indexShortened),
 

--- a/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Linq/Internal/InternalElementAtOrAbsent.IList.cs
+++ b/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Linq/Internal/InternalElementAtOrAbsent.IList.cs
@@ -10,12 +10,9 @@ namespace System.Linq
             this IList<TSource> source,
             in int index)
             =>
-            index switch
+            (index >= 0 && index < source.Count) switch
             {
-                _ when index >= 0 && index < source.Count
-                =>
-                Optional.Present(source[index]),
-
+                true => Optional.Present(source[index]),
                 _ => default
             };
 
@@ -25,9 +22,9 @@ namespace System.Linq
             =>
             unchecked((int)index) switch
             {
-                var indexNormalized when indexNormalized == index
+                var indexShortened when indexShortened == index
                 =>
-                source.InternalElementAtOrAbsent(indexNormalized),
+                source.InternalElementAtOrAbsent(indexShortened),
 
                 _ => default
             };

--- a/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Linq/Internal/InternalElementAtOrAbsent.IReadOnlyList.cs
+++ b/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Linq/Internal/InternalElementAtOrAbsent.IReadOnlyList.cs
@@ -10,12 +10,9 @@ namespace System.Linq
             this IReadOnlyList<TSource> source,
             in int index)
             =>
-            index switch
+            (index >= 0 && index < source.Count) switch
             {
-                _ when index >= 0 && index < source.Count
-                =>
-                Optional.Present(source[index]),
-
+                true => Optional.Present(source[index]),
                 _ => default
             };
 
@@ -25,9 +22,9 @@ namespace System.Linq
             =>
             unchecked((int)index) switch
             {
-                var indexNormalized when indexNormalized == index
+                var indexShortened when indexShortened == index
                 =>
-                source.InternalElementAtOrAbsent(indexNormalized),
+                source.InternalElementAtOrAbsent(indexShortened),
 
                 _ => default
             };

--- a/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Linq/Internal/InternalElementAtOrAbsent.IReadOnlyList.cs
+++ b/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Linq/Internal/InternalElementAtOrAbsent.IReadOnlyList.cs
@@ -10,7 +10,7 @@ namespace System.Linq
             this IReadOnlyList<TSource> source,
             in int index)
             =>
-            (index >= 0 && index < source.Count) switch
+            InternalIsInRange(index, source.Count) switch
             {
                 true => Optional.Present(source[index]),
                 _ => default
@@ -20,9 +20,9 @@ namespace System.Linq
             this IReadOnlyList<TSource> source,
             in long index)
             =>
-            unchecked((int)index) switch
+            InternalShortenIndex(index) switch
             {
-                var indexShortened when indexShortened == index
+                int indexShortened when indexShortened == index
                 =>
                 source.InternalElementAtOrAbsent(indexShortened),
 

--- a/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Linq/Internal/InternalFirstOrAbsent.IList.cs
+++ b/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Linq/Internal/InternalFirstOrAbsent.IList.cs
@@ -8,14 +8,12 @@ namespace System.Linq
     {
         public static Optional<TSource> InternalFirstOrAbsent<TSource>(
             this IList<TSource> source)
-        {
-            if (source.Count > 0)
+            =>
+            source.Count switch
             {
-                return Optional.Present(source[0]);
-            }
-
-            return default;
-        }
+                > 0 => Optional.Present(source[0]),
+                _ => default
+            };
 
         public static Optional<TSource> InternalFirstOrAbsent<TSource>(
             this IList<TSource> source,

--- a/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Linq/Internal/InternalFirstOrAbsent.IReadOnlyList.cs
+++ b/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Linq/Internal/InternalFirstOrAbsent.IReadOnlyList.cs
@@ -8,14 +8,12 @@ namespace System.Linq
     {
         public static Optional<TSource> InternalFirstOrAbsent<TSource>(
             this IReadOnlyList<TSource> source)
-        {
-            if (source.Count > 0)
+            =>
+            source.Count switch
             {
-                return Optional.Present(source[0]);
-            }
-
-            return default;
-        }
+                > 0 => Optional.Present(source[0]),
+                _ => default
+            };
 
         public static Optional<TSource> InternalFirstOrAbsent<TSource>(
             this IReadOnlyList<TSource> source,

--- a/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Linq/Internal/InternalFirstOrAbsent.cs
+++ b/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Linq/Internal/InternalFirstOrAbsent.cs
@@ -11,12 +11,11 @@ namespace System.Linq
         {
             using var enumerator = source.GetEnumerator();
 
-            if (enumerator.MoveNext())
+            return enumerator.MoveNext() switch
             {
-                return Optional.Present(enumerator.Current);
-            }
-
-            return default;
+                true => Optional.Present(enumerator.Current),
+                _ => default
+            };
         }
 
         public static Optional<TSource> InternalFirstOrAbsent<TSource>(

--- a/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Linq/Internal/InternalIsInRange.cs
+++ b/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Linq/Internal/InternalIsInRange.cs
@@ -1,0 +1,9 @@
+﻿#nullable enable
+
+namespace System.Linq
+{
+    partial class InternalCollectionsExtensions
+    {
+        private static bool InternalIsInRange(in int index, in int count) => index >= 0 && index < count;
+    }
+}

--- a/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Linq/Internal/InternalLastOrAbsent.IList.cs
+++ b/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Linq/Internal/InternalLastOrAbsent.IList.cs
@@ -8,14 +8,12 @@ namespace System.Linq
     {
         public static Optional<TSource> InternalLastOrAbsent<TSource>(
             this IList<TSource> source)
-        {
-            if (source.Count > 0)
+            =>
+            source.Count switch
             {
-                return Optional.Present(source[^1]);
-            }
-
-            return default;
-        }
+                > 0 => Optional.Present(source[^1]),
+                _ => default
+            };
 
         public static Optional<TSource> InternalLastOrAbsent<TSource>(
             this IList<TSource> source,

--- a/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Linq/Internal/InternalLastOrAbsent.IReadOnlyList.cs
+++ b/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Linq/Internal/InternalLastOrAbsent.IReadOnlyList.cs
@@ -8,14 +8,12 @@ namespace System.Linq
     {
         public static Optional<TSource> InternalLastOrAbsent<TSource>(
             this IReadOnlyList<TSource> source)
-        {
-            if (source.Count > 0)
+            =>
+            source.Count switch
             {
-                return Optional.Present(source[^1]);
-            }
-
-            return default;
-        }
+                > 0 => Optional.Present(source[^1]),
+                _ => default
+            };
 
         public static Optional<TSource> InternalLastOrAbsent<TSource>(
             this IReadOnlyList<TSource> source,

--- a/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Linq/Internal/InternalShortenIndex.cs
+++ b/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Linq/Internal/InternalShortenIndex.cs
@@ -1,0 +1,9 @@
+﻿#nullable enable
+
+namespace System.Linq
+{
+    partial class InternalCollectionsExtensions
+    {
+        private static int InternalShortenIndex(in long index) => unchecked((int)index);
+    }
+}

--- a/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Linq/Internal/InternalSingleOrAbsent.IList.cs
+++ b/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Linq/Internal/InternalSingleOrAbsent.IList.cs
@@ -12,7 +12,7 @@ namespace System.Linq
             =>
             source.Count switch
             {
-                var count when count > 1 => throw moreThanOneElementExceptionFactory.Invoke(),
+                > 1 => throw moreThanOneElementExceptionFactory.Invoke(),
 
                 1 => Optional.Present(source[0]),
 

--- a/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Linq/Internal/InternalSingleOrAbsent.IReadOnlyList.cs
+++ b/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Linq/Internal/InternalSingleOrAbsent.IReadOnlyList.cs
@@ -12,7 +12,7 @@ namespace System.Linq
             =>
             source.Count switch
             {
-                var count when count > 1 => throw moreThanOneElementExceptionFactory.Invoke(),
+                > 1 => throw moreThanOneElementExceptionFactory.Invoke(),
 
                 1 => Optional.Present(source[0]),
 

--- a/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Linq/LastOrAbsent.IReadOnlyList.cs
+++ b/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Linq/LastOrAbsent.IReadOnlyList.cs
@@ -9,10 +9,7 @@ namespace System.Linq
         public static Optional<TSource> LastOrAbsent<TSource>(
             this IReadOnlyList<TSource> source)
         {
-            if (source is null)
-            {
-                throw new ArgumentNullException(nameof(source));
-            }
+            _ = source ?? throw new ArgumentNullException(nameof(source));
 
             return source.InternalLastOrAbsent();
         }
@@ -21,15 +18,8 @@ namespace System.Linq
             this IReadOnlyList<TSource> source,
             in Func<TSource, bool> predicate)
         {
-            if (source is null)
-            {
-                throw new ArgumentNullException(nameof(source));
-            }
-
-            if (predicate is null)
-            {
-                throw new ArgumentNullException(nameof(predicate));
-            }
+            _ = source ?? throw new ArgumentNullException(nameof(source));
+            _ = predicate ?? throw new ArgumentNullException(nameof(predicate));
 
             return source.InternalLastOrAbsent(predicate);
         }

--- a/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Linq/LastOrAbsent.cs
+++ b/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Linq/LastOrAbsent.cs
@@ -9,10 +9,7 @@ namespace System.Linq
         public static Optional<TSource> LastOrAbsent<TSource>(
             this IEnumerable<TSource> source)
         {
-            if (source is null)
-            {
-                throw new ArgumentNullException(nameof(source));
-            }
+            _ = source ?? throw new ArgumentNullException(nameof(source));
 
             return source switch
             {
@@ -34,15 +31,8 @@ namespace System.Linq
             this IEnumerable<TSource> source,
             in Func<TSource, bool> predicate)
         {
-            if (source is null)
-            {
-                throw new ArgumentNullException(nameof(source));
-            }
-
-            if (predicate is null)
-            {
-                throw new ArgumentNullException(nameof(predicate));
-            }
+            _ = source ?? throw new ArgumentNullException(nameof(source));
+            _ = predicate ?? throw new ArgumentNullException(nameof(predicate));
 
             return source switch
             {

--- a/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Linq/SingleOrAbsent.IReadOnlyList.cs
+++ b/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Linq/SingleOrAbsent.IReadOnlyList.cs
@@ -15,15 +15,8 @@ namespace System.Linq
             this IReadOnlyList<TSource> source,
             in Func<Exception> moreThanOneElementExceptionFactory)
         {
-            if (source is null)
-            {
-                throw new ArgumentNullException(nameof(source));
-            }
-
-            if (moreThanOneElementExceptionFactory is null)
-            {
-                throw new ArgumentNullException(nameof(moreThanOneElementExceptionFactory));
-            }
+            _ = source ?? throw new ArgumentNullException(nameof(source));
+            _ = moreThanOneElementExceptionFactory ?? throw new ArgumentNullException(nameof(moreThanOneElementExceptionFactory));
 
             return source.InternalSingleOrAbsent(moreThanOneElementExceptionFactory);
         }
@@ -39,20 +32,9 @@ namespace System.Linq
             in Func<TSource, bool> predicate,
             in Func<Exception> moreThanOneMatchExceptionFactory)
         {
-            if (source is null)
-            {
-                throw new ArgumentNullException(nameof(source));
-            }
-
-            if (predicate is null)
-            {
-                throw new ArgumentNullException(nameof(predicate));
-            }
-
-            if (moreThanOneMatchExceptionFactory is null)
-            {
-                throw new ArgumentNullException(nameof(moreThanOneMatchExceptionFactory));
-            }
+            _ = source ?? throw new ArgumentNullException(nameof(source));
+            _ = predicate ?? throw new ArgumentNullException(nameof(predicate));
+            _ = moreThanOneMatchExceptionFactory ?? throw new ArgumentNullException(nameof(moreThanOneMatchExceptionFactory));
 
             return source.InternalSingleOrAbsent(predicate, moreThanOneMatchExceptionFactory);
         }

--- a/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Linq/SingleOrAbsent.cs
+++ b/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Linq/SingleOrAbsent.cs
@@ -15,15 +15,8 @@ namespace System.Linq
             this IEnumerable<TSource> source,
             in Func<Exception> moreThanOneElementExceptionFactory)
         {
-            if (source is null)
-            {
-                throw new ArgumentNullException(nameof(source));
-            }
-
-            if (moreThanOneElementExceptionFactory is null)
-            {
-                throw new ArgumentNullException(nameof(moreThanOneElementExceptionFactory));
-            }
+            _ = source ?? throw new ArgumentNullException(nameof(source));
+            _ = moreThanOneElementExceptionFactory ?? throw new ArgumentNullException(nameof(moreThanOneElementExceptionFactory));
 
             return source switch
             {
@@ -52,20 +45,9 @@ namespace System.Linq
             in Func<TSource, bool> predicate,
             in Func<Exception> moreThanOneMatchExceptionFactory)
         {
-            if (source is null)
-            {
-                throw new ArgumentNullException(nameof(source));
-            }
-
-            if (predicate is null)
-            {
-                throw new ArgumentNullException(nameof(predicate));
-            }
-
-            if (moreThanOneMatchExceptionFactory is null)
-            {
-                throw new ArgumentNullException(nameof(moreThanOneMatchExceptionFactory));
-            }
+            _ = source ?? throw new ArgumentNullException(nameof(source));
+            _ = predicate ?? throw new ArgumentNullException(nameof(predicate));
+            _ = moreThanOneMatchExceptionFactory ?? throw new ArgumentNullException(nameof(moreThanOneMatchExceptionFactory));
 
             return source switch
             {

--- a/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Optional.Extensions.FilterNotNull/FilterNotNullOrThrow.cs
+++ b/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Optional.Extensions.FilterNotNull/FilterNotNullOrThrow.cs
@@ -10,10 +10,7 @@ namespace System
 
         public static Optional<T> FilterNotNullOrThrow<T>(this in Optional<T> optional, Func<Exception> exceptionFactory)
         {
-            if (exceptionFactory is null)
-            {
-                throw new ArgumentNullException(nameof(exceptionFactory));
-            }
+            _ = exceptionFactory ?? throw new ArgumentNullException(nameof(exceptionFactory));
 
             return optional.Filter(value => value switch
             {

--- a/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Optional.T.Filter.cs
+++ b/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Optional.T.Filter.cs
@@ -6,10 +6,7 @@ namespace System
     {
         public Optional<T> Filter(in Func<T, bool> predicate)
         {
-            if (predicate is null)
-            {
-                throw new ArgumentNullException(nameof(predicate));
-            }
+            _ = predicate ?? throw new ArgumentNullException(nameof(predicate));
 
             var @this = this;
             var thePredicate = predicate;

--- a/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Optional.T.ImplFold.cs
+++ b/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Optional.T.ImplFold.cs
@@ -6,15 +6,8 @@ namespace System
     {
         private TResult ImplFold<TResult>(in Func<T, TResult> onPresent, in Func<TResult> onAbsent)
         {
-            if (onPresent is null)
-            {
-                throw new ArgumentNullException(nameof(onPresent));
-            }
-
-            if (onAbsent is null)
-            {
-                throw new ArgumentNullException(nameof(onAbsent));
-            }
+            _ = onPresent ?? throw new ArgumentNullException(nameof(onPresent));
+            _ = onAbsent ?? throw new ArgumentNullException(nameof(onAbsent));
 
             return box switch
             {
@@ -25,15 +18,8 @@ namespace System
 
         private TResult ImplFold<TResult>(in Func<TResult> onPresent, in Func<TResult> onAbsent)
         {
-            if (onPresent is null)
-            {
-                throw new ArgumentNullException(nameof(onPresent));
-            }
-
-            if (onAbsent is null)
-            {
-                throw new ArgumentNullException(nameof(onAbsent));
-            }
+            _ = onPresent ?? throw new ArgumentNullException(nameof(onPresent));
+            _ = onAbsent ?? throw new ArgumentNullException(nameof(onAbsent));
 
             return box switch
             {

--- a/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Optional.T.Map.cs
+++ b/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Optional.T.Map.cs
@@ -6,10 +6,7 @@ namespace System
     {
         public Optional<TResult> Map<TResult>(in Func<T, TResult> map)
         {
-            if (map is null)
-            {
-                throw new ArgumentNullException(nameof(map));
-            }
+            _ = map ?? throw new ArgumentNullException(nameof(map));
 
             var theMap = map;
 

--- a/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Optional.T.Or.cs
+++ b/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Optional.T.Or.cs
@@ -8,20 +8,14 @@ namespace System
     {
         public Optional<T> Or(in Func<Optional<T>> otherFactory)
         {
-            if (otherFactory is null)
-            {
-                throw new ArgumentNullException(nameof(otherFactory));
-            }
+            _ = otherFactory ?? throw new ArgumentNullException(nameof(otherFactory));
 
             return ImplFold(This, otherFactory);
         }
 
         public Task<Optional<T>> OrAsync(in Func<Task<Optional<T>>> otherFactoryAsync)
         {
-            if (otherFactoryAsync is null)
-            {
-                throw new ArgumentNullException(nameof(otherFactoryAsync));
-            }
+            _ = otherFactoryAsync ?? throw new ArgumentNullException(nameof(otherFactoryAsync));
 
             return ImplFold(ThisAsync, otherFactoryAsync);
         }

--- a/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Optional.T.OrElse.cs
+++ b/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Optional.T.OrElse.cs
@@ -15,20 +15,14 @@ namespace System
 
         public T OrElse(in Func<T> otherFactory)
         {
-            if (otherFactory is null)
-            {
-                throw new ArgumentNullException(nameof(otherFactory));
-            }
+            _ = otherFactory ?? throw new ArgumentNullException(nameof(otherFactory));
 
             return ImplFold(value => value, otherFactory);
         }
 
         public Task<T> OrElseAsync(in Func<Task<T>> otherFactoryAsync)
         {
-            if (otherFactoryAsync is null)
-            {
-                throw new ArgumentNullException(nameof(otherFactoryAsync));
-            }
+            _ = otherFactoryAsync ?? throw new ArgumentNullException(nameof(otherFactoryAsync));
 
             return ImplFold(Task.FromResult, otherFactoryAsync);
         }

--- a/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Optional.T.OrThrow.cs
+++ b/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Optional.T.OrThrow.cs
@@ -8,10 +8,7 @@ namespace System
 
         public T OrThrow(in Func<Exception> exceptionFactory)
         {
-            if (exceptionFactory is null)
-            {
-                throw new ArgumentNullException(nameof(exceptionFactory));
-            }
+            _ = exceptionFactory ?? throw new ArgumentNullException(nameof(exceptionFactory));
 
             var theExceptionFactory = exceptionFactory;
 

--- a/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Optional.T.cs
+++ b/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Optional/Optional.T.cs
@@ -8,7 +8,7 @@ namespace System
     {
         private readonly Box<T>? box;
 
-        public bool IsPresent => box is object;
+        public bool IsPresent => box is not null;
 
         public bool IsAbsent => box is null;
 

--- a/src/PrimeFuncPack.Core/PrimeFuncPack.Core.TaggedUnion/TaggedUnion.2.ImplFold.cs
+++ b/src/PrimeFuncPack.Core/PrimeFuncPack.Core.TaggedUnion/TaggedUnion.2.ImplFold.cs
@@ -8,15 +8,8 @@ namespace System
             Func<TFirst, TResult> mapFirst,
             Func<TSecond, TResult> mapSecond)
         {
-            if (mapFirst is null)
-            {
-                throw new ArgumentNullException(nameof(mapFirst));
-            }
-
-            if (mapSecond is null)
-            {
-                throw new ArgumentNullException(nameof(mapSecond));
-            }
+            _ = mapFirst ?? throw new ArgumentNullException(nameof(mapFirst));
+            _ = mapSecond ?? throw new ArgumentNullException(nameof(mapSecond));
 
             var @this = this;
 

--- a/src/PrimeFuncPack.Core/PrimeFuncPack.Core.TaggedUnion/TaggedUnion.2.cs
+++ b/src/PrimeFuncPack.Core/PrimeFuncPack.Core.TaggedUnion/TaggedUnion.2.cs
@@ -12,8 +12,8 @@ namespace System
 
         public bool IsInitialized => IsFirst || IsSecond;
 
-        public bool IsFirst => boxFirst is object;
+        public bool IsFirst => boxFirst is not null;
 
-        public bool IsSecond => boxSecond is object;
+        public bool IsSecond => boxSecond is not null;
     }
 }

--- a/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Unit/Unit.InvokeAction.cs
+++ b/src/PrimeFuncPack.Core/PrimeFuncPack.Core.Unit/Unit.InvokeAction.cs
@@ -6,10 +6,7 @@ namespace System
     {
         public static Unit InvokeAction(in Action action)
         {
-            if (action is null)
-            {
-                throw new ArgumentNullException(nameof(action));
-            }
+            _ = action ?? throw new ArgumentNullException(nameof(action));
 
             action.Invoke();
 
@@ -18,10 +15,7 @@ namespace System
 
         public static Unit InvokeAction<T>(in Action<T> action, in T obj)
         {
-            if (action is null)
-            {
-                throw new ArgumentNullException(nameof(action));
-            }
+            _ = action ?? throw new ArgumentNullException(nameof(action));
 
             action.Invoke(obj);
 
@@ -33,10 +27,7 @@ namespace System
             in T1 arg1,
             in T2 arg2)
         {
-            if (action is null)
-            {
-                throw new ArgumentNullException(nameof(action));
-            }
+            _ = action ?? throw new ArgumentNullException(nameof(action));
 
             action.Invoke(
                 arg1,
@@ -51,10 +42,7 @@ namespace System
             in T2 arg2,
             in T3 arg3)
         {
-            if (action is null)
-            {
-                throw new ArgumentNullException(nameof(action));
-            }
+            _ = action ?? throw new ArgumentNullException(nameof(action));
 
             action.Invoke(
                 arg1,
@@ -71,10 +59,7 @@ namespace System
             in T3 arg3,
             in T4 arg4)
         {
-            if (action is null)
-            {
-                throw new ArgumentNullException(nameof(action));
-            }
+            _ = action ?? throw new ArgumentNullException(nameof(action));
 
             action.Invoke(
                 arg1,
@@ -93,10 +78,7 @@ namespace System
             in T4 arg4,
             in T5 arg5)
         {
-            if (action is null)
-            {
-                throw new ArgumentNullException(nameof(action));
-            }
+            _ = action ?? throw new ArgumentNullException(nameof(action));
 
             action.Invoke(
                 arg1,
@@ -117,10 +99,7 @@ namespace System
             in T5 arg5,
             in T6 arg6)
         {
-            if (action is null)
-            {
-                throw new ArgumentNullException(nameof(action));
-            }
+            _ = action ?? throw new ArgumentNullException(nameof(action));
 
             action.Invoke(
                 arg1,
@@ -143,10 +122,7 @@ namespace System
             in T6 arg6,
             in T7 arg7)
         {
-            if (action is null)
-            {
-                throw new ArgumentNullException(nameof(action));
-            }
+            _ = action ?? throw new ArgumentNullException(nameof(action));
 
             action.Invoke(
                 arg1,
@@ -171,10 +147,7 @@ namespace System
             in T7 arg7,
             in T8 arg8)
         {
-            if (action is null)
-            {
-                throw new ArgumentNullException(nameof(action));
-            }
+            _ = action ?? throw new ArgumentNullException(nameof(action));
 
             action.Invoke(
                 arg1,
@@ -201,10 +174,7 @@ namespace System
             in T8 arg8,
             in T9 arg9)
         {
-            if (action is null)
-            {
-                throw new ArgumentNullException(nameof(action));
-            }
+            _ = action ?? throw new ArgumentNullException(nameof(action));
 
             action.Invoke(
                 arg1,
@@ -233,10 +203,7 @@ namespace System
             in T9 arg9,
             in T10 arg10)
         {
-            if (action is null)
-            {
-                throw new ArgumentNullException(nameof(action));
-            }
+            _ = action ?? throw new ArgumentNullException(nameof(action));
 
             action.Invoke(
                 arg1,
@@ -267,10 +234,7 @@ namespace System
             in T10 arg10,
             in T11 arg11)
         {
-            if (action is null)
-            {
-                throw new ArgumentNullException(nameof(action));
-            }
+            _ = action ?? throw new ArgumentNullException(nameof(action));
 
             action.Invoke(
                 arg1,
@@ -303,10 +267,7 @@ namespace System
             in T11 arg11,
             in T12 arg12)
         {
-            if (action is null)
-            {
-                throw new ArgumentNullException(nameof(action));
-            }
+            _ = action ?? throw new ArgumentNullException(nameof(action));
 
             action.Invoke(
                 arg1,
@@ -341,10 +302,7 @@ namespace System
             in T12 arg12,
             in T13 arg13)
         {
-            if (action is null)
-            {
-                throw new ArgumentNullException(nameof(action));
-            }
+            _ = action ?? throw new ArgumentNullException(nameof(action));
 
             action.Invoke(
                 arg1,
@@ -381,10 +339,7 @@ namespace System
             in T13 arg13,
             in T14 arg14)
         {
-            if (action is null)
-            {
-                throw new ArgumentNullException(nameof(action));
-            }
+            _ = action ?? throw new ArgumentNullException(nameof(action));
 
             action.Invoke(
                 arg1,
@@ -423,10 +378,7 @@ namespace System
             in T14 arg14,
             in T15 arg15)
         {
-            if (action is null)
-            {
-                throw new ArgumentNullException(nameof(action));
-            }
+            _ = action ?? throw new ArgumentNullException(nameof(action));
 
             action.Invoke(
                 arg1,
@@ -467,10 +419,7 @@ namespace System
             in T15 arg15,
             in T16 arg16)
         {
-            if (action is null)
-            {
-                throw new ArgumentNullException(nameof(action));
-            }
+            _ = action ?? throw new ArgumentNullException(nameof(action));
 
             action.Invoke(
                 arg1,

--- a/src/PrimeFuncPack.DependencyInjection/PrimeFuncPack.DependencyInjection/Extensions/DependencyInjectionBuilderExtensions.cs
+++ b/src/PrimeFuncPack.DependencyInjection/PrimeFuncPack.DependencyInjection/Extensions/DependencyInjectionBuilderExtensions.cs
@@ -18,15 +18,8 @@ namespace Microsoft.Extensions.DependencyInjection
             in Action<TServiceCollectionProvider> action)
             where TServiceCollectionProvider : notnull, IServiceCollectionProvider
         {
-            if (provider is null)
-            {
-                throw new ArgumentNullException(nameof(provider));
-            }
-
-            if (action is null)
-            {
-                throw new ArgumentNullException(nameof(action));
-            }
+            _ = provider ?? throw new ArgumentNullException(nameof(provider));
+            _ = action ?? throw new ArgumentNullException(nameof(action));
 
             action.Invoke(provider);
             return provider;
@@ -38,15 +31,8 @@ namespace Microsoft.Extensions.DependencyInjection
             where TSourceProvider : notnull, IServiceCollectionProvider
             where TResultProvider : notnull, IServiceCollectionProvider
         {
-            if (provider is null)
-            {
-                throw new ArgumentNullException(nameof(provider));
-            }
-
-            if (pipe is null)
-            {
-                throw new ArgumentNullException(nameof(pipe));
-            }
+            _ = provider ?? throw new ArgumentNullException(nameof(provider));
+            _ = pipe ?? throw new ArgumentNullException(nameof(pipe));
 
             return pipe.Invoke(provider);
         }

--- a/src/PrimeFuncPack.DependencyInjection/PrimeFuncPack.DependencyInjection/ServiceBuilder/IServiceBuilder.MapService.cs
+++ b/src/PrimeFuncPack.DependencyInjection/PrimeFuncPack.DependencyInjection/ServiceBuilder/IServiceBuilder.MapService.cs
@@ -10,10 +10,7 @@ namespace PrimeFuncPack.DependencyInjection
         public IServiceBuilder<TResult> Map<TResult>(Func<TService, TResult> map)
             where TResult : class
         {
-            if (map is null)
-            {
-                throw new ArgumentNullException(nameof(map));
-            }
+            _ = map ?? throw new ArgumentNullException(nameof(map));
 
             return Services.UseBuilder(
                 sp => Resolve(sp) switch { var service => map.Invoke(service) });
@@ -22,10 +19,7 @@ namespace PrimeFuncPack.DependencyInjection
         public IServiceBuilder<TResult> Map<TResult>(Func<IServiceProvider, TService, TResult> map)
             where TResult : class
         {
-            if (map is null)
-            {
-                throw new ArgumentNullException(nameof(map));
-            }
+            _ = map ?? throw new ArgumentNullException(nameof(map));
 
             return Services.UseBuilder(
                 sp => Resolve(sp) switch { var service => map.Invoke(sp, service) });


### PR DESCRIPTION
- Migrate to C# 9: Use "not null" pattern
- Migrate to C# 9: Use switch expression with logical patterns
- Functional approach: Implement check "not null" argument contract as "_ = arg ?? throw"
- Refactor: more functional approach